### PR TITLE
fix: CCIE-4861 improve repo 404 error

### DIFF
--- a/patchstorm/github_utils.py
+++ b/patchstorm/github_utils.py
@@ -1,6 +1,6 @@
 import os
 import time
-from github import Github
+from github import Github, UnknownObjectException
 from github import Auth
 from typing import Dict, List
 
@@ -48,7 +48,9 @@ def get_repo_prs(repo_name: str) -> List:
     """
     auth = Auth.Token(GITHUB_TOKEN)
     g = Github(auth=auth)
-    repo = g.get_repo(repo_name)
-
+    try:
+        repo = g.get_repo(repo_name)
+    except UnknownObjectException as e:
+        raise RuntimeError(f"Repository {repo_name} not found or inaccessible.") from e
     # has attributes like number, title, url, draft
     return repo.get_pulls(state='open')


### PR DESCRIPTION
```
    repo = g.get_repo(repo_name)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/github/MainClass.py", line 471, in get_repo
    headers, data = self.__requester.requestJsonAndCheck("GET", url)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/github/Requester.py", line 624, in requestJsonAndCheck
    return self.__check(
           ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/github/Requester.py", line 792, in __check
    raise self.createException(status, responseHeaders, data)
github.GithubException.UnknownObjectException: 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest/repos/repos#get-a-repository", "status": "404"}

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/run_agent.py", line 227, in <module>
    if config.commit_msg in {pr.title for pr in get_repo_prs(repo)}:
                                                ^^^^^^^^^^^^^^^^^^
  File "/app/patchstorm/github_utils.py", line 54, in get_repo_prs
    raise RuntimeError(f"Repository {repo_name} not found or inaccessible.") from e
RuntimeError: Repository chanzuckerberg/patchstormzz not found or inaccessible.
```