### PR TITLE
feat: CCIE-5185 union search_query and repos together

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+To run tests, run `make test`

--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ agent:
   provider: claude_code|codex
 commit:
   message: "commit message, eg chore: upgrade to fogg 0.92.27"
-search_query: '"set up working directory by installing dependencies"'
+repos:
+  include:
+    - "chanzuckerberg/fogg"
+  exclude:
+    - "chanzuckerberg/some-other-repo"
+  search_query: '"set up working directory by installing dependencies"'
 prompts:
   - prompt: "update the version string in .fogg-version to 0.92.27. If you edit the version string, make sure the makefile setup target is downloading the correct fogg version."
   - prompt: "in the root fogg.yml file, if there are any self references to the repo using a git url pinned to the main branch instead of a relative path, change it to use a relative path instead."
@@ -75,6 +80,8 @@ When you have written a task definition, you can use this shortcut:
 ./shortcut.sh [path to task definition] --commit-msg "Upgrade Fogg to latest version" --dry
 ```
 
+The order of operations for the repos block is the union of the include list and the search query,
+minus any repos in the exclude list.
 
 ## Make Targets
 

--- a/patchstorm/github_utils.py
+++ b/patchstorm/github_utils.py
@@ -12,17 +12,23 @@ def get_repos(repos=None, search_query=None):
     Get repositories based on repo name or search query.
     
     Args:
-        repo (str, optional): A specific repo to run against.
+        repos (str, optional): A specific repo to run against (comma-separated).
         search_query (str, optional): Search query to find repos.
         
     Returns:
         set: Set of repository names.
         
     Raises:
-        ValueError: If neither repo nor search_query is provided.
+        ValueError: If neither repos nor search_query is provided.
     """
-    if repos is None:
-        repos = set()
+    result_repos = set()
+    
+    # Handle repos parameter if provided
+    if repos:
+        # Convert comma-separated string to set of repo names
+        result_repos.update({r.strip() for r in repos.split(',')})
+    
+    # Handle search_query parameter if provided
     if search_query:
         auth = Auth.Token(GITHUB_TOKEN)
         g = Github(auth=auth)
@@ -30,16 +36,15 @@ def get_repos(repos=None, search_query=None):
         paginated = g.search_code(f'org:{GITHUB_ORGANIZATION} {search_query} NOT is:archived')
         print(f"Processing {paginated.totalCount} repo results")
         for i, page in enumerate(paginated):
-            repos.add(page.repository.full_name)
+            result_repos.add(page.repository.full_name)
             time.sleep(0.2)
             if not i % 25:
                 print(f"{i / paginated.totalCount:.2%} done")
-    elif repos:
-        repos = {r.strip() for r in repos.split(',')}
-    else:
-        raise ValueError("You must specify either repos or search_query.")
-
-    return repos
+    
+    if not result_repos:
+        raise ValueError("No repositories found with the provided repos or search_query parameters.")
+        
+    return result_repos
 
 
 def get_repo_prs(repo_name: str) -> List:

--- a/patchstorm/task_definition.py
+++ b/patchstorm/task_definition.py
@@ -31,13 +31,20 @@ properties:
         prompt:
           type: string
   repos:
-    type: array
-    description: List of repositories to run against.
-    items:
-      type: string
+    type: object
+    description: Repository configuration for running tasks.
+    properties:
+      include:
+        type: array
+        description: List of repositories to run against.
+        items:
+          type: string
+      search_query:
+        type: string
+        description: GitHub search query to find repositories.
   search_query:
     type: string
-    description: GitHub search query to find repositories.
+    description: GitHub search query to find repositories (legacy format, prefer repos.search_query).
   draft:
     type: boolean
     description: Whether to create pull requests as drafts. Defaults to false if not specified.

--- a/patchstorm/tests/test_task_definition.py
+++ b/patchstorm/tests/test_task_definition.py
@@ -1,5 +1,6 @@
 import pytest
 import unittest.mock as mock
+import warnings
 from patchstorm.task_definition import validate_task_definition_yaml
 import sys
 import os
@@ -20,21 +21,6 @@ def test_valid_task_definition():
     """)
 
 
-def test_valid_task_definition_with_repos():
-    """Test that a task definition with repos is validated correctly."""
-    assert True == validate_task_definition_yaml("""
-    agent: 
-        provider: codex
-    commit:
-        message: "Test commit message"
-    prompts:
-        - prompt: "Test prompt"
-    repos:
-        - mygithuborg/repo1
-        - mygithuborg/repo2
-    """)
-
-
 def test_valid_task_definition_with_search_query():
     """Test that a task definition with search_query is validated correctly."""
     assert True == validate_task_definition_yaml("""
@@ -45,6 +31,23 @@ def test_valid_task_definition_with_search_query():
     prompts:
         - prompt: "Test prompt"
     search_query: "path:.github language:YAML"
+    """)
+
+
+def test_valid_task_definition_with_repos_new_format():
+    """Test that a task definition with repos in new format is validated correctly."""
+    assert True == validate_task_definition_yaml("""
+    agent: 
+        provider: codex
+    commit:
+        message: "Test commit message"
+    prompts:
+        - prompt: "Test prompt"
+    repos:
+        include:
+            - chanzuckerberg/patchstorm
+            - chanzuckerberg/fogg
+        search_query: '"set up working directory by installing dependencies" 0.92.2'
     """)
 
 
@@ -105,10 +108,18 @@ def test_missing_commit_message():
 
 @mock.patch('run_agent.get_repos')
 def test_convert_task_def_to_config(mock_get_repos):
-    """Test converting a task definition to RunAgentConfig."""
-    # Setup mock to return a set of repos
-    mock_get_repos.return_value = {"test/repo", "another/repo"}
+    """Test converting a task definition to RunAgentConfig and test include/search_query union."""
+    # Setup mock with different results for different search queries
+    def mock_get_repos_side_effect(repos, search_query):
+        if repos == "test/repo,another/repo":
+            return {"test/repo", "another/repo"}
+        elif search_query == "path:.github language:YAML":
+            return {"search/repo1", "search/repo2"}
+        return set()
     
+    mock_get_repos.side_effect = mock_get_repos_side_effect
+    
+    # First test with command line override
     task_def = {
         "agent": {
             "provider": "codex"
@@ -121,7 +132,10 @@ def test_convert_task_def_to_config(mock_get_repos):
                 "prompt": "Test prompt"
             }
         ],
-        "repos": ["default/repo"]
+        "repos": {
+            "include": ["include/repo1", "include/repo2"],
+            "search_query": "path:.github language:YAML"
+        }
     }
     
     config = create_config_from_task_definition(task_def, repos="test/repo,another/repo")
@@ -130,47 +144,21 @@ def test_convert_task_def_to_config(mock_get_repos):
     assert config.commit_msg == "Test commit message"
     assert config.prompts == ["Test prompt"]
     assert config.agent_provider == "codex"
+    # Command line parameters take precedence
     assert config.repos == {"test/repo", "another/repo"}
     assert not config.skip_pr
     assert not config.dry
     assert not config.draft  # Default is False
     mock_get_repos.assert_called_with("test/repo,another/repo", None)
-
-
-@mock.patch('run_agent.get_repos')
-def test_convert_task_def_with_repos_to_config(mock_get_repos):
-    """Test that repos defined in task definition are used in RunAgentConfig."""
-    # Setup mock to return test repos
-    mock_get_repos.side_effect = lambda repos, search_query: {r.strip() for r in repos.split(',')} if repos else set()
     
-    task_def = {
-        "agent": {
-            "provider": "codex"
-        },
-        "commit": {
-            "message": "Test commit message"
-        },
-        "prompts": [
-            {
-                "prompt": "Test prompt"
-            }
-        ],
-        "repos": [
-            "mygithuborg/repo1",
-            "mygithuborg/repo2"
-        ]
-    }
-
-    # without specifying repo parameter, repos from task definition should be used
+    # Now test the union behavior with both include and search_query
     config = create_config_from_task_definition(task_def)
-
+    
     assert isinstance(config, RunAgentConfig)
-    assert config.repos == {"mygithuborg/repo1", "mygithuborg/repo2"}
-
-    # repos parameter is specified, should override repos from task definition
-    config_override = create_config_from_task_definition(task_def, repos="test/override")
-    assert config_override.repos == {"test/override"}
-    mock_get_repos.assert_called_with("test/override", None)
+    # Should be the union of repos from include and search_query
+    expected_repos = {"include/repo1", "include/repo2", "search/repo1", "search/repo2"}
+    assert config.repos == expected_repos
+    mock_get_repos.assert_called_with(None, "path:.github language:YAML")
 
 
 @mock.patch('run_agent.get_repos')
@@ -205,6 +193,144 @@ def test_convert_task_def_with_search_query_to_config(mock_get_repos):
     assert config.repos == {"found/repo1", "found/repo2"}
     mock_get_repos.assert_called_with(None, "override:query")
 
+@mock.patch('run_agent.get_repos')
+def test_convert_task_def_with_combined_repos_and_top_level_search_query(mock_get_repos):
+    """Test that repositories from include are combined with those found by top-level search_query."""
+    # Setup mock for different search query results
+    def mock_get_repos_side_effect(repos, search_query):
+        if search_query == "path:.github language:YAML":
+            return {"found/repo1", "found/repo2"}
+        return set()
+    
+    mock_get_repos.side_effect = mock_get_repos_side_effect
+    
+    task_def = {
+        "agent": {
+            "provider": "codex"
+        },
+        "commit": {
+            "message": "Test commit message"
+        },
+        "prompts": [
+            {
+                "prompt": "Test prompt"
+            }
+        ],
+        "repos": {
+            "include": [
+                "chanzuckerberg/patchstorm",
+                "chanzuckerberg/fogg"
+            ]
+        },
+        "search_query": "path:.github language:YAML"
+    }
+    
+    # Test combining repos from include and top-level search_query
+    config = create_config_from_task_definition(task_def)
+    assert isinstance(config, RunAgentConfig)
+    # Should combine repositories from include and search_query
+    expected_repos = {"chanzuckerberg/patchstorm", "chanzuckerberg/fogg", "found/repo1", "found/repo2"}
+    assert config.repos == expected_repos
+    mock_get_repos.assert_called_with(None, "path:.github language:YAML")
+
+
+@mock.patch('run_agent.get_repos')
+def test_convert_task_def_with_repos_new_format_to_config(mock_get_repos):
+    """Test that repos defined in new format are used in RunAgentConfig."""
+    # Setup mock to return test repos for include list and search query results
+    mock_repos_from_query = {"found/repo1", "found/repo2"}
+    
+    def mock_get_repos_side_effect(repos, search_query):
+        if repos:
+            return {r.strip() for r in repos.split(',')}
+        elif search_query:
+            return mock_repos_from_query
+        return set()
+    
+    mock_get_repos.side_effect = mock_get_repos_side_effect
+    
+    # Test with include list only
+    task_def = {
+        "agent": {
+            "provider": "codex"
+        },
+        "commit": {
+            "message": "Test commit message"
+        },
+        "prompts": [
+            {
+                "prompt": "Test prompt"
+            }
+        ],
+        "repos": {
+            "include": [
+                "chanzuckerberg/patchstorm",
+                "chanzuckerberg/fogg"
+            ]
+        }
+    }
+    
+    config = create_config_from_task_definition(task_def)
+    assert isinstance(config, RunAgentConfig)
+    assert config.repos == {"chanzuckerberg/patchstorm", "chanzuckerberg/fogg"}
+    
+    # Test with search_query only
+    task_def = {
+        "agent": {
+            "provider": "codex"
+        },
+        "commit": {
+            "message": "Test commit message"
+        },
+        "prompts": [
+            {
+                "prompt": "Test prompt"
+            }
+        ],
+        "repos": {
+            "search_query": '"set up working directory by installing dependencies" 0.92.2'
+        }
+    }
+    
+    config = create_config_from_task_definition(task_def)
+    assert isinstance(config, RunAgentConfig)
+    assert config.repos == mock_repos_from_query
+    mock_get_repos.assert_called_with(None, '"set up working directory by installing dependencies" 0.92.2')
+    
+    # Test with both include and search_query - SHOULD COMBINE RESULTS
+    task_def = {
+        "agent": {
+            "provider": "codex"
+        },
+        "commit": {
+            "message": "Test commit message"
+        },
+        "prompts": [
+            {
+                "prompt": "Test prompt"
+            }
+        ],
+        "repos": {
+            "include": [
+                "chanzuckerberg/patchstorm",
+                "chanzuckerberg/fogg"
+            ],
+            "search_query": '"set up working directory by installing dependencies" 0.92.2'
+        }
+    }
+    
+    config = create_config_from_task_definition(task_def)
+    assert isinstance(config, RunAgentConfig)
+    # Should combine both sets of repositories
+    expected_repos = {"chanzuckerberg/patchstorm", "chanzuckerberg/fogg", "found/repo1", "found/repo2"}
+    assert config.repos == expected_repos
+    mock_get_repos.assert_called_with(None, '"set up working directory by installing dependencies" 0.92.2')
+    
+    # Command line override of repos
+    config = create_config_from_task_definition(task_def, repos="override/repo")
+    assert config.repos == {"override/repo"}
+    mock_get_repos.assert_called_with("override/repo", None)
+
 
 @mock.patch('run_agent.get_repos')
 def test_convert_task_def_with_draft_to_config(mock_get_repos):
@@ -212,7 +338,7 @@ def test_convert_task_def_with_draft_to_config(mock_get_repos):
     # Setup mock to return a set of repos
     mock_get_repos.return_value = {"test/repo"}
     
-    # Test with draft=true in task definition
+    # Test with draft=true in task definition - using new object format
     task_def_with_draft = {
         "agent": {
             "provider": "codex"
@@ -225,7 +351,9 @@ def test_convert_task_def_with_draft_to_config(mock_get_repos):
                 "prompt": "Test prompt"
             }
         ],
-        "repos": ["test/repo"],
+        "repos": {
+            "include": ["test/repo"]
+        },
         "draft": True
     }
     
@@ -233,7 +361,7 @@ def test_convert_task_def_with_draft_to_config(mock_get_repos):
     assert isinstance(config, RunAgentConfig)
     assert config.draft is True
     
-    # Test with draft=false in task definition
+    # Test with draft=false in task definition - using new object format
     task_def_without_draft = {
         "agent": {
             "provider": "codex"
@@ -246,7 +374,9 @@ def test_convert_task_def_with_draft_to_config(mock_get_repos):
                 "prompt": "Test prompt"
             }
         ],
-        "repos": ["test/repo"],
+        "repos": {
+            "include": ["test/repo"]
+        },
         "draft": False
     }
     
@@ -262,8 +392,11 @@ def test_convert_task_def_with_draft_to_config(mock_get_repos):
     assert config.draft is False
 
 
-def test_task_def_with_both_repos_and_search_query():
-    """Test that specifying both repos and search_query raises NotImplementedError."""
+@mock.patch('run_agent.get_repos')
+def test_task_def_with_both_legacy_repos_and_search_query(mock_get_repos):
+    """Test that legacy repos format with search_query now fails with a ValueError."""
+    mock_get_repos.return_value = {"found/repo1", "found/repo2"}
+    
     task_def = {
         "agent": {
             "provider": "codex"
@@ -276,13 +409,41 @@ def test_task_def_with_both_repos_and_search_query():
                 "prompt": "Test prompt"
             }
         ],
-        "repos": ["mygithuborg/repo1"],
+        # Legacy format is no longer supported
+        "repos": ["mygithuborg/repo1", "mygithuborg/repo2"],
         "search_query": "path:.github language:YAML"
+    }
+    
+    # Test should raise ValueError because legacy format is no longer supported
+    with pytest.raises(ValueError) as excinfo:
+        create_config_from_task_definition(task_def)
+    
+    assert "'repos' must be an object" in str(excinfo.value)
+    
+    
+def test_task_def_with_conflicting_search_queries():
+    """Test that specifying both repos.search_query and top-level search_query raises NotImplementedError."""
+    task_def = {
+        "agent": {
+            "provider": "codex"
+        },
+        "commit": {
+            "message": "Test commit message"
+        },
+        "prompts": [
+            {
+                "prompt": "Test prompt"
+            }
+        ],
+        "repos": {
+            "search_query": "query1"
+        },
+        "search_query": "query2"
     }
     
     with pytest.raises(NotImplementedError) as excinfo:
         create_config_from_task_definition(task_def)
-    assert "Cannot specify both 'repos' and 'search_query'" in str(excinfo.value)
+    assert "Cannot specify both 'repos.search_query' and top-level 'search_query'" in str(excinfo.value)
 
 
 def test_task_def_missing_required_fields():


### PR DESCRIPTION
changes the interface of task definition to top level repos

```
repos:
  include:
    - "chanzuckerberg/fogg"
  exclude:
    - "chanzuckerberg/some-other-repo"
  search_query: '"set up working directory by installing dependencies"'
```

Unions the results of include with search query. In upcoming PR I will then removes exclude.

Applies to cmdline interface as well
```
rzheng@CZIMACOS4883 patchstorm % docker compose exec worker python run_agent.py --prompt "PROMPT HERE" --commit-msg "COMMIT MESSAGE HERE" --repos chanzuckerberg/patchstorm-private --dry --search-query "CZI_RELEASE_PLEASE_APP_ID language:yml path:.github"
Processing 3 repo results
0.00% done
would run with prompts: ['PROMPT HERE']
commit message: COMMIT MESSAGE HERE
reviewers: set()
agent provider: codex
skip PR: False
running against 4 repo(s):
  chanzuckerberg/patchstorm-private
  chanzuckerberg/czid-graphql-federation-server-private
  chanzuckerberg/vcp-cli
  chanzuckerberg/vcp-model-asset-pipeline
Would run on chanzuckerberg/patchstorm-private
Would run on chanzuckerberg/czid-graphql-federation-server-private
Would run on chanzuckerberg/vcp-cli
Would run on chanzuckerberg/vcp-model-asset-pipeline
```